### PR TITLE
`build-url` includes scheme

### DIFF
--- a/src/sentry_tiny/core.clj
+++ b/src/sentry_tiny/core.clj
@@ -119,7 +119,7 @@
    https://github.com/ring-clojure/ring/wiki/Concepts"
   [{port :server-port :keys [scheme server-name uri]}]
   (str (when scheme (str (name scheme) "://")) server-name
-       (when (and port (not= 80 port))
+       (when (and port (not= ({:http 80 :https 443} scheme) port))
          (str ":" port))
        uri))
 
@@ -131,6 +131,15 @@
                      :server-name "some.host"
                      :server-port 1234
                      :uri         "/path"})))
+
+  (are [url scheme port]
+       (= url (build-url {:scheme scheme :server-port port}))
+       "http://" :http 80
+       "http://:1" :http 1
+       "https://" :https 443
+       "https://:1" :https 1
+       "unknown://" :unknown nil
+       "unknown://:1" :unknown 1)
   )
 
 (defn- http-info [req]

--- a/src/sentry_tiny/core.clj
+++ b/src/sentry_tiny/core.clj
@@ -114,7 +114,10 @@
                    (add-info "sentry.interfaces.User" user-info req)
                    (add-stacktrace e namespaces))))))
 
-(defn- build-url [{port :server-port :keys [scheme server-name uri]}]
+(defn- build-url
+  "Reconstruct a URL from a ring request map, using the keys defined in
+   https://github.com/ring-clojure/ring/wiki/Concepts"
+  [{port :server-port :keys [scheme server-name uri]}]
   (str (when scheme (str (name scheme) "://")) server-name
        (when (and port (not= 80 port))
          (str ":" port))

--- a/src/sentry_tiny/core.clj
+++ b/src/sentry_tiny/core.clj
@@ -115,10 +115,20 @@
                    (add-stacktrace e namespaces))))))
 
 (defn- build-url [{port :server-port :keys [scheme server-name uri]}]
-  (str (when scheme (name scheme) "://") server-name
+  (str (when scheme (str (name scheme) "://")) server-name
        (when (and port (not= 80 port))
          (str ":" port))
        uri))
+
+(comment
+  (use 'clojure.test)
+
+  (is (= "https://some.host:1234/path"
+         (build-url {:scheme      :https
+                     :server-name "some.host"
+                     :server-port 1234
+                     :uri         "/path"})))
+  )
 
 (defn- http-info [req]
   {:url          (build-url req)


### PR DESCRIPTION
# Problem

```clojure
(build-url {:scheme      :https
                     :server-name "some.host"
                     :server-port 1234
                     :uri         "/path"})
;; => "://some.host:1234/path"
```

As a result, the Sentry web interface simply didn't show the :uri on the web interface.

Additionally, I also added logic to omit the default port number for the `:https` scheme too, not just the `:http` scheme.

I've provided some tests, but just in a rich comment block, since there is not test tooling anyway.