### PR TITLE
Replace `clj-time` with `java.time`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,4 @@
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cheshire "5.10.1"]
-                 [http-kit "2.5.3"]
-                 [clj-time "0.15.2"]])
+                 [http-kit "2.5.3"]])

--- a/src/sentry_tiny/core.clj
+++ b/src/sentry_tiny/core.clj
@@ -3,13 +3,12 @@
     [clojure.string :as str]
     [clojure.java.io :as io]
     [org.httpkit.client :as http]
-    [cheshire.core :as json]
-    [clj-time
-     [core :as t]
-     [format :as ft]])
+    [cheshire.core :as json])
   (:import
     (java.net InetAddress)
-    (java.util UUID)))
+    (java.util UUID)
+    (java.time OffsetDateTime ZoneOffset)
+    (java.time.format DateTimeFormatter)))
 
 (defonce ^:private fallback (atom {:enabled? false}))
 
@@ -80,6 +79,13 @@
 
 (def ^:private elevel (memoize -level))
 
+(def ^:private timestamp-fmt "YYYY-MM-dd'T'HH:mm:ss")
+
+(defn- timestamp
+  ([] (timestamp (OffsetDateTime/now ZoneOffset/UTC)))
+  ([^OffsetDateTime date-time]
+   (-> date-time (.format (DateTimeFormatter/ofPattern timestamp-fmt)))))
+
 (defn capture
   "Send a message to a Sentry server.
   event-info is a map that should contain a :message key and optional
@@ -92,7 +98,7 @@
          {:level       (elevel level)
           :platform    "clojure"
           :server_name @hostname
-          :timestamp   (ft/unparse (ft/formatters :date-hour-minute-second) (t/now))
+          :timestamp   (timestamp)
           :event_id    (generate-uuid)}
          event-info))))
 


### PR DESCRIPTION
# Problem

`clj-time` is an overkill to compute and format a timestamp only once in the library.
This extra dependency can conflicts in bigger project, like a Datomic Cloud ion application, where the Datomic platform already assumes certain versions of dependencies.

# Solution

Use the more modern `java.time` package instead of `clj-time`, which is a built-in, since Java 8.
